### PR TITLE
Update CI workspace and fixes testing cases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,8 @@
 ---
+workspace:
+  base: /go
+  path: /src/k8s.io/helm
+
 pipeline:
   build:
     image: golang:1.10

--- a/pkg/releasetesting/environment_test.go
+++ b/pkg/releasetesting/environment_test.go
@@ -177,6 +177,6 @@ func newCreateFailingKubeClient() *createFailingKubeClient {
 	}
 }
 
-func (p *createFailingKubeClient) Create(ns string, r io.Reader, t int64, shouldWait bool) error {
+func (p *createFailingKubeClient) Create(rn, ns string, r io.Reader, t int64, shouldWait bool) error {
 	return errors.New("We ran out of budget and couldn't create finding-nemo")
 }

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -150,7 +150,7 @@ type PrintingKubeClient struct {
 }
 
 // Create prints the values of what would be created with a real KubeClient.
-func (p *PrintingKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
+func (p *PrintingKubeClient) Create(rn, ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	_, err := io.Copy(p.Out, r)
 	return err
 }

--- a/pkg/tiller/environment/environment_test.go
+++ b/pkg/tiller/environment/environment_test.go
@@ -40,7 +40,7 @@ func (e *mockEngine) Render(chrt *chart.Chart, v chartutil.Values) (map[string]s
 
 type mockKubeClient struct{}
 
-func (k *mockKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
+func (k *mockKubeClient) Create(rn, ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	return nil
 }
 func (k *mockKubeClient) Get(ns string, r io.Reader) (string, error) {

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -503,7 +503,7 @@ func (kc *mockHooksKubeClient) makeManifest(r io.Reader) (*mockHooksManifest, er
 
 	return manifest, nil
 }
-func (kc *mockHooksKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
+func (kc *mockHooksKubeClient) Create(rn, ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	manifest, err := kc.makeManifest(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Problem:**
1. https://github.com/rancher/helm/pull/13#issuecomment-457274887 CI/CD build is failed because of incorrect workspace issue, more details on (https://drone7.rancher.io/rancher/helm/2/3)

2. run `make test-unit` will fail because the testing cases are not up-to-the-date with rancher's comment changes.

**Solution:**
1. The workspace path is required to be set to `$GOPATH/src/k8s.io/helm` according to the helm doc https://docs.helm.sh/developers/#building-helm-tiller . 
And add workspace path `/go/src/k8s.io/helm/ ` to the `.drone.yaml` .

2. Updating the test cases accordingly.

**Related PRs:**
https://github.com/rancher/helm/pull/13#issuecomment-457274887
