### PR TITLE
address recreat resource appId label is not unique by info name

### DIFF
--- a/cmd/rudder/rudder.go
+++ b/cmd/rudder/rudder.go
@@ -131,7 +131,7 @@ func (r *ReleaseModuleServiceServer) RollbackRelease(ctx context.Context, in *ru
 	grpclog.Print("rollback")
 	c := bytes.NewBufferString(in.Current.Manifest)
 	t := bytes.NewBufferString(in.Target.Manifest)
-	err := kubeClient.Update(in.Target.Namespace, c, t, in.Force, in.Recreate, in.Timeout, in.Wait)
+	err := kubeClient.Update(in.Target.Name, in.Target.Namespace, c, t, in.Force, in.Recreate, in.Timeout, in.Wait)
 	return &rudderAPI.RollbackReleaseResponse{}, err
 }
 
@@ -140,7 +140,7 @@ func (r *ReleaseModuleServiceServer) UpgradeRelease(ctx context.Context, in *rud
 	grpclog.Print("upgrade")
 	c := bytes.NewBufferString(in.Current.Manifest)
 	t := bytes.NewBufferString(in.Target.Manifest)
-	err := kubeClient.Update(in.Target.Namespace, c, t, in.Force, in.Recreate, in.Timeout, in.Wait)
+	err := kubeClient.Update(in.Target.Name, in.Target.Namespace, c, t, in.Force, in.Recreate, in.Timeout, in.Wait)
 	// upgrade response object should be changed to include status
 	return &rudderAPI.UpgradeReleaseResponse{}, err
 }

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -185,7 +185,7 @@ func TestUpdate(t *testing.T) {
 	rf := &fakeReaperFactory{Factory: tf, reaper: reaper}
 	c.Client.Factory = rf
 	codec := legacyscheme.Codecs.LegacyCodec(scheme.Versions...)
-	if err := c.Update(core.NamespaceDefault, objBody(codec, &listA), objBody(codec, &listB), false, false, 0, false); err != nil {
+	if err := c.Update("name", core.NamespaceDefault, objBody(codec, &listA), objBody(codec, &listB), false, false, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	// TODO: Find a way to test methods that use Client Set

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -133,7 +133,7 @@ type KubeClient interface {
 	//
 	// reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n").
-	Update(namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error
+	Update(name, namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error
 
 	Build(namespace string, reader io.Reader) (kube.Result, error)
 	BuildUnstructured(namespace string, reader io.Reader) (kube.Result, error)
@@ -176,7 +176,7 @@ func (p *PrintingKubeClient) WatchUntilReady(ns string, r io.Reader, timeout int
 }
 
 // Update implements KubeClient Update.
-func (p *PrintingKubeClient) Update(ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+func (p *PrintingKubeClient) Update(n, ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	_, err := io.Copy(p.Out, modifiedReader)
 	return err
 }

--- a/pkg/tiller/environment/environment_test.go
+++ b/pkg/tiller/environment/environment_test.go
@@ -49,7 +49,7 @@ func (k *mockKubeClient) Get(ns string, r io.Reader) (string, error) {
 func (k *mockKubeClient) Delete(ns string, r io.Reader) error {
 	return nil
 }
-func (k *mockKubeClient) Update(ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+func (k *mockKubeClient) Update(n, ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	return nil
 }
 func (k *mockKubeClient) WatchUntilReady(ns string, r io.Reader, timeout int64, shouldWait bool) error {

--- a/pkg/tiller/release_modules.go
+++ b/pkg/tiller/release_modules.go
@@ -59,14 +59,14 @@ func (m *LocalReleaseModule) Create(r *release.Release, req *services.InstallRel
 func (m *LocalReleaseModule) Update(current, target *release.Release, req *services.UpdateReleaseRequest, env *environment.Environment) error {
 	c := bytes.NewBufferString(current.Manifest)
 	t := bytes.NewBufferString(target.Manifest)
-	return env.KubeClient.Update(target.Namespace, c, t, req.Force, req.Recreate, req.Timeout, req.Wait)
+	return env.KubeClient.Update(target.Name, target.Namespace, c, t, req.Force, req.Recreate, req.Timeout, req.Wait)
 }
 
 // Rollback performs a rollback from current to target release
 func (m *LocalReleaseModule) Rollback(current, target *release.Release, req *services.RollbackReleaseRequest, env *environment.Environment) error {
 	c := bytes.NewBufferString(current.Manifest)
 	t := bytes.NewBufferString(target.Manifest)
-	return env.KubeClient.Update(target.Namespace, c, t, req.Force, req.Recreate, req.Timeout, req.Wait)
+	return env.KubeClient.Update(target.Name, target.Namespace, c, t, req.Force, req.Recreate, req.Timeout, req.Wait)
 }
 
 // Status returns kubectl-like formatted status of release objects

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -431,7 +431,7 @@ type updateFailingKubeClient struct {
 	environment.PrintingKubeClient
 }
 
-func (u *updateFailingKubeClient) Update(namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+func (u *updateFailingKubeClient) Update(name, namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	return errors.New("Failed update in kube client")
 }
 
@@ -547,7 +547,7 @@ func (kc *mockHooksKubeClient) WatchUntilReady(ns string, r io.Reader, timeout i
 
 	return nil
 }
-func (kc *mockHooksKubeClient) Update(ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+func (kc *mockHooksKubeClient) Update(n, ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	return nil
 }
 func (kc *mockHooksKubeClient) Build(ns string, reader io.Reader) (kube.Result, error) {


### PR DESCRIPTION
**Problem:**
`info.Name` will be different for the created resources like service, deployment, configmap and etc., so it is not a valid value for the label `io.cattle.field/appId`.

**Solution:**
1. add to pass release name to helm `Update` function and use it for the `io.cattle.field/appId` instead of `info.Name`
2. move the recreate resource call to a separate function, so for a new created k8s resource its label won't be updated twice which it does in the [original method](https://github.com/rancher/helm/blob/b0da822eb0e6049fd20a90db884cfd3ea35bc0a0/pkg/kube/client.go#L435) . 

**Issues:**
https://github.com/rancher/rancher/issues/17754

**Related PRs:**
N/A

**Validation Steps:**
1. deploy the catalog app `drone`, and set the `service.type` to `NodePort` (default to NodePort).
2. ensure all the resources are showing properly in the catalog page.
**==== Test Upgrade ====** 
3. upgrade the deployed catalog apps and change the `service.type` to `ClusterIP` with `Delete and recreate resources if needed during the upgrade` checked.
4. ensure all the resources are showing properly in the catalog page.
5. upgrade the deployed catalog apps and change the `service.type` to `NodePort`.
6. ensure all the resources are showing properly in the catalog page.
**==== Test Rollback ====** 
7. rollback the deployed catalog apps and choose the `service.type` to `ClusterIP` with `Delete and recreate resources if needed during the upgrade` checked.
8. ensure all the resources are showing properly in the catalog page.