### PR TITLE
Update 2.14 with rancher changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,68 @@
+---
+kind: pipeline
+name: default
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /go
+  path: /src/k8s.io/helm
+
+steps:
+  - name: build
+    pull: default
+    image: golang:1.12.9
+    commands:
+      - ./.circleci/bootstrap.sh
+      - make test-unit
+      - make build-cross
+      - mv ./_dist/linux-arm64/rancher-helm ./_dist/linux-arm64/rancher-helm-arm64
+      - mv ./_dist/linux-arm64/rancher-tiller ./_dist/linux-arm64/rancher-tiller-arm64
+    environment:
+      PROJECT_NAME: '"kubernetes-helm"'
+      TARGETS: linux/amd64 linux/arm64
+
+  - name: publish-github-rc
+    pull: default
+    image: plugins/github-release
+    settings:
+      api_key:
+        from_secret: github_token
+      checksum:
+        - sha256
+      files:
+        - "bin/*"
+        - _dist/linux-amd64/*
+        - _dist/linux-arm64/*
+      prerelease: true
+    when:
+      instance:
+        - drone-publish.rancher.io
+      event:
+        - tag
+      ref:
+        - "refs/tags/*rc*"
+        - refs/heads/rancher
+
+  - name: github_binary_release
+    pull: default
+    image: plugins/github-release
+    settings:
+      checksum:
+        - sha256
+      files:
+        - "bin/*"
+        - _dist/linux-amd64/*
+        - _dist/linux-arm64/*
+      api_key:
+        from_secret: github_token
+    when:
+      instance:
+        - drone-publish.rancher.io
+      event:
+        - tag
+      ref:
+        exclude:
+          - "refs/tags/*rc*"

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ build:
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
-	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
-	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
+	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/rancher-helm" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/helm
+	CGO_ENABLED=0 gox -parallel=3 -output="_dist/{{.OS}}-{{.Arch}}/rancher-tiller" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' k8s.io/helm/cmd/tiller
 
 .PHONY: dist
 dist:
@@ -156,6 +156,9 @@ clean:
 .PHONY: coverage
 coverage:
 	@scripts/coverage.sh
+
+.PHONY: release
+release: bootstrap build
 
 HAS_GLIDE := $(shell command -v glide;)
 HAS_GOX := $(shell command -v gox;)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Helm
 
-[![CircleCI](https://circleci.com/gh/helm/helm.svg?style=shield)](https://circleci.com/gh/helm/helm)
-[![Go Report Card](https://goreportcard.com/badge/github.com/helm/helm)](https://goreportcard.com/report/github.com/helm/helm)
-[![GoDoc](https://godoc.org/k8s.io/helm?status.svg)](https://godoc.org/k8s.io/helm)
-
 Helm is a tool for managing Kubernetes charts. Charts are packages of
 pre-configured Kubernetes resources.
 

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -229,7 +229,11 @@ func (t *templateCmd) run(cmd *cobra.Command, args []string) error {
 	for _, m := range tiller.SortByKind(manifestsToRender) {
 		data := m.Content
 		b := filepath.Base(m.Name)
-		if !t.showNotes && b == "NOTES.txt" {
+		if t.showNotes {
+			if b != "NOTES.txt" {
+				continue
+			}
+		} else if b == "NOTES.txt" {
 			continue
 		}
 		if strings.HasPrefix(b, "_") {

--- a/cmd/rudder/rudder.go
+++ b/cmd/rudder/rudder.go
@@ -91,7 +91,7 @@ func (r *ReleaseModuleServiceServer) Version(ctx context.Context, in *rudderAPI.
 func (r *ReleaseModuleServiceServer) InstallRelease(ctx context.Context, in *rudderAPI.InstallReleaseRequest) (*rudderAPI.InstallReleaseResponse, error) {
 	grpclog.Print("install")
 	b := bytes.NewBufferString(in.Release.Manifest)
-	err := kubeClient.Create(in.Release.Namespace, b, 500, false)
+	err := kubeClient.Create(in.Release.Name, in.Release.Namespace, b, 500, false)
 	if err != nil {
 		grpclog.Printf("error when creating release: %v", err)
 	}
@@ -131,7 +131,7 @@ func (r *ReleaseModuleServiceServer) RollbackRelease(ctx context.Context, in *ru
 	grpclog.Print("rollback")
 	c := bytes.NewBufferString(in.Current.Manifest)
 	t := bytes.NewBufferString(in.Target.Manifest)
-	err := kubeClient.UpdateWithOptions(in.Target.Namespace, c, t, kube.UpdateOptions{
+	err := kubeClient.UpdateWithOptions(in.Target.Name, in.Target.Namespace, c, t, kube.UpdateOptions{
 		Force:         in.Force,
 		Recreate:      in.Recreate,
 		Timeout:       in.Timeout,
@@ -146,7 +146,7 @@ func (r *ReleaseModuleServiceServer) UpgradeRelease(ctx context.Context, in *rud
 	grpclog.Print("upgrade")
 	c := bytes.NewBufferString(in.Current.Manifest)
 	t := bytes.NewBufferString(in.Target.Manifest)
-	err := kubeClient.UpdateWithOptions(in.Target.Namespace, c, t, kube.UpdateOptions{
+	err := kubeClient.UpdateWithOptions(in.Target.Name, in.Target.Namespace, c, t, kube.UpdateOptions{
 		Force:         in.Force,
 		Recreate:      in.Recreate,
 		Timeout:       in.Timeout,

--- a/cmd/tiller/tiller.go
+++ b/cmd/tiller/tiller.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
 
 	// Import to initialize client auth plugins.
@@ -125,11 +126,15 @@ func main() {
 }
 
 func start() {
-
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("Tiller", healthpb.HealthCheckResponse_NOT_SERVING)
 
-	clientset, err := kube.New(nil).KubernetesClientSet()
+	kubeconfig := os.Getenv("KUBECONFIG")
+
+	flagset := genericclioptions.NewConfigFlags(true)
+	flagset.KubeConfig = &kubeconfig
+
+	clientset, err := kube.New(flagset).KubernetesClientSet()
 	if err != nil {
 		logger.Fatalf("Cannot initialize Kubernetes connection: %s", err)
 	}
@@ -167,7 +172,7 @@ func start() {
 		env.Releases.MaxHistory = *maxHistory
 	}
 
-	kubeClient := kube.New(nil)
+	kubeClient := kube.New(flagset)
 	kubeClient.Log = newLogger("kube").Printf
 	env.KubeClient = kubeClient
 
@@ -215,18 +220,22 @@ func start() {
 
 	srvErrCh := make(chan error)
 	probeErrCh := make(chan error)
-	go func() {
+	done := make(chan struct{})
+	go func(done chan<- struct{}) {
 		svc := tiller.NewReleaseServer(env, clientset, *remoteReleaseModules)
 		svc.Log = newLogger("tiller").Printf
 		services.RegisterReleaseServiceServer(rootServer, svc)
+		done <- struct{}{}
 		if err := rootServer.Serve(lstn); err != nil {
 			srvErrCh <- err
 		}
-	}()
+	}(done)
 
-	go func() {
+	go func(done <-chan struct{}) {
 		mux := newProbesMux()
 
+		// wait for the first go routine to register services
+		<-done
 		// Register gRPC server to prometheus to initialized matrix
 		goprom.Register(rootServer)
 		addPrometheusHandler(mux)
@@ -234,7 +243,7 @@ func start() {
 		if err := http.ListenAndServe(*probeAddr, mux); err != nil {
 			probeErrCh <- err
 		}
-	}()
+	}(done)
 
 	healthSrv.SetServingStatus("Tiller", healthpb.HealthCheckResponse_SERVING)
 

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -200,7 +200,7 @@ func TestUpdate(t *testing.T) {
 		Log:     nopLogger,
 	}
 
-	if err := c.Update(v1.NamespaceDefault, objBody(&listA), objBody(&listB), false, false, 0, false); err != nil {
+	if err := c.Update("", v1.NamespaceDefault, objBody(&listA), objBody(&listB), false, false, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	// TODO: Find a way to test methods that use Client Set
@@ -236,7 +236,7 @@ func TestUpdate(t *testing.T) {
 	// Test resource policy is respected
 	actions = nil
 	listA.Items[2].ObjectMeta.Annotations = map[string]string{ResourcePolicyAnno: "keep"}
-	if err := c.Update(v1.NamespaceDefault, objBody(&listA), objBody(&listB), false, false, 0, false); err != nil {
+	if err := c.Update("", v1.NamespaceDefault, objBody(&listA), objBody(&listB), false, false, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, v := range actions {
@@ -274,7 +274,7 @@ func TestUpdateNonManagedResourceError(t *testing.T) {
 		Log:     nopLogger,
 	}
 
-	if err := c.Update(v1.NamespaceDefault, objBody(&current), objBody(&target), false, false, 0, false); err != nil {
+	if err := c.Update("", v1.NamespaceDefault, objBody(&current), objBody(&target), false, false, 0, false); err != nil {
 		if err.Error() != "kind Pod with the name \"starfish\" already exists in the cluster and wasn't defined in the previous release. Before upgrading, please either delete the resource from the cluster or remove it from the chart" {
 			t.Fatal(err)
 		}
@@ -647,13 +647,13 @@ func TestPerform(t *testing.T) {
 func TestReal(t *testing.T) {
 	t.Skip("This is a live test, comment this line to run")
 	c := New(nil)
-	if err := c.Create("test", strings.NewReader(guestbookManifest), 300, false); err != nil {
+	if err := c.Create("", "test", strings.NewReader(guestbookManifest), 300, false); err != nil {
 		t.Fatal(err)
 	}
 
 	testSvcEndpointManifest := testServiceManifest + "\n---\n" + testEndpointManifest
 	c = New(nil)
-	if err := c.Create("test-delete", strings.NewReader(testSvcEndpointManifest), 300, false); err != nil {
+	if err := c.Create("", "test-delete", strings.NewReader(testSvcEndpointManifest), 300, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/releasetesting/environment.go
+++ b/pkg/releasetesting/environment.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"k8s.io/helm/pkg/proto/hapi/release"
 	"k8s.io/helm/pkg/proto/hapi/services"
@@ -43,7 +43,7 @@ type Environment struct {
 
 func (env *Environment) createTestPod(test *test) error {
 	b := bytes.NewBufferString(test.manifest)
-	if err := env.KubeClient.Create(env.Namespace, b, env.Timeout, false); err != nil {
+	if err := env.KubeClient.Create("", env.Namespace, b, env.Timeout, false); err != nil {
 		log.Printf(err.Error())
 		test.result.Info = err.Error()
 		test.result.Status = release.TestRun_FAILURE

--- a/pkg/releasetesting/environment_test.go
+++ b/pkg/releasetesting/environment_test.go
@@ -178,6 +178,6 @@ func newCreateFailingKubeClient() *createFailingKubeClient {
 	}
 }
 
-func (p *createFailingKubeClient) Create(ns string, r io.Reader, t int64, shouldWait bool) error {
+func (p *createFailingKubeClient) Create(name, ns string, r io.Reader, t int64, shouldWait bool) error {
 	return errors.New("We ran out of budget and couldn't create finding-nemo")
 }

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -108,7 +108,7 @@ type KubeClient interface {
 	//
 	// reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n").
-	Create(namespace string, reader io.Reader, timeout int64, shouldWait bool) error
+	Create(name, namespace string, reader io.Reader, timeout int64, shouldWait bool) error
 
 	// Get gets one or more resources. Returned string hsa the format like kubectl
 	// provides with the column headers separating the resource types.
@@ -145,7 +145,7 @@ type KubeClient interface {
 	WatchUntilReady(namespace string, reader io.Reader, timeout int64, shouldWait bool) error
 
 	// Deprecated; use UpdateWithOptions instead
-	Update(namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error
+	Update(name, namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error
 
 	// UpdateWithOptions updates one or more resources or creates the resource
 	// if it doesn't exist.
@@ -154,7 +154,7 @@ type KubeClient interface {
 	//
 	// reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n").
-	UpdateWithOptions(namespace string, originalReader, modifiedReader io.Reader, opts kube.UpdateOptions) error
+	UpdateWithOptions(name, namespace string, originalReader, modifiedReader io.Reader, opts kube.UpdateOptions) error
 
 	Build(namespace string, reader io.Reader) (kube.Result, error)
 
@@ -185,7 +185,7 @@ type PrintingKubeClient struct {
 }
 
 // Create prints the values of what would be created with a real KubeClient.
-func (p *PrintingKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
+func (p *PrintingKubeClient) Create(name, ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	_, err := io.Copy(p.Out, r)
 	return err
 }
@@ -219,8 +219,8 @@ func (p *PrintingKubeClient) WatchUntilReady(ns string, r io.Reader, timeout int
 }
 
 // Update implements KubeClient Update.
-func (p *PrintingKubeClient) Update(ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
-	return p.UpdateWithOptions(ns, currentReader, modifiedReader, kube.UpdateOptions{
+func (p *PrintingKubeClient) Update(name, ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+	return p.UpdateWithOptions(name, ns, currentReader, modifiedReader, kube.UpdateOptions{
 		Force:      force,
 		Recreate:   recreate,
 		Timeout:    timeout,
@@ -229,7 +229,7 @@ func (p *PrintingKubeClient) Update(ns string, currentReader, modifiedReader io.
 }
 
 // UpdateWithOptions implements KubeClient UpdateWithOptions.
-func (p *PrintingKubeClient) UpdateWithOptions(ns string, currentReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
+func (p *PrintingKubeClient) UpdateWithOptions(name, ns string, currentReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
 	_, err := io.Copy(p.Out, modifiedReader)
 	return err
 }

--- a/pkg/tiller/environment/environment_test.go
+++ b/pkg/tiller/environment/environment_test.go
@@ -40,7 +40,7 @@ func (e *mockEngine) Render(chrt *chart.Chart, v chartutil.Values) (map[string]s
 
 type mockKubeClient struct{}
 
-func (k *mockKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
+func (k *mockKubeClient) Create(name, ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	return nil
 }
 func (k *mockKubeClient) Get(ns string, r io.Reader) (string, error) {
@@ -52,10 +52,10 @@ func (k *mockKubeClient) Delete(ns string, r io.Reader) error {
 func (k *mockKubeClient) DeleteWithTimeout(ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	return nil
 }
-func (k *mockKubeClient) Update(ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+func (k *mockKubeClient) Update(name, ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	return nil
 }
-func (k *mockKubeClient) UpdateWithOptions(ns string, currentReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
+func (k *mockKubeClient) UpdateWithOptions(name, ns string, currentReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
 	return nil
 }
 func (k *mockKubeClient) WatchUntilReady(ns string, r io.Reader, timeout int64, shouldWait bool) error {
@@ -117,7 +117,7 @@ func TestKubeClient(t *testing.T) {
 		b.WriteString(content)
 	}
 
-	if err := env.KubeClient.Create("sharry-bobbins", b, 300, false); err != nil {
+	if err := env.KubeClient.Create("", "sharry-bobbins", b, 300, false); err != nil {
 		t.Errorf("Kubeclient failed: %s", err)
 	}
 }

--- a/pkg/tiller/release_modules.go
+++ b/pkg/tiller/release_modules.go
@@ -51,14 +51,14 @@ type LocalReleaseModule struct {
 // Create creates a release via kubeclient from provided environment
 func (m *LocalReleaseModule) Create(r *release.Release, req *services.InstallReleaseRequest, env *environment.Environment) error {
 	b := bytes.NewBufferString(r.Manifest)
-	return env.KubeClient.Create(r.Namespace, b, req.Timeout, req.Wait)
+	return env.KubeClient.Create(r.Name, r.Namespace, b, req.Timeout, req.Wait)
 }
 
 // Update performs an update from current to target release
 func (m *LocalReleaseModule) Update(current, target *release.Release, req *services.UpdateReleaseRequest, env *environment.Environment) error {
 	c := bytes.NewBufferString(current.Manifest)
 	t := bytes.NewBufferString(target.Manifest)
-	return env.KubeClient.UpdateWithOptions(target.Namespace, c, t, kube.UpdateOptions{
+	return env.KubeClient.UpdateWithOptions(target.Name, target.Namespace, c, t, kube.UpdateOptions{
 		Force:         req.Force,
 		Recreate:      req.Recreate,
 		Timeout:       req.Timeout,
@@ -71,7 +71,7 @@ func (m *LocalReleaseModule) Update(current, target *release.Release, req *servi
 func (m *LocalReleaseModule) Rollback(current, target *release.Release, req *services.RollbackReleaseRequest, env *environment.Environment) error {
 	c := bytes.NewBufferString(current.Manifest)
 	t := bytes.NewBufferString(target.Manifest)
-	return env.KubeClient.UpdateWithOptions(target.Namespace, c, t, kube.UpdateOptions{
+	return env.KubeClient.UpdateWithOptions(target.Name, target.Namespace, c, t, kube.UpdateOptions{
 		Force:         req.Force,
 		Recreate:      req.Recreate,
 		Timeout:       req.Timeout,

--- a/pkg/tiller/release_server.go
+++ b/pkg/tiller/release_server.go
@@ -284,6 +284,8 @@ func GetVersionSet(client discovery.ServerGroupsInterface) (chartutil.VersionSet
 func (s *ReleaseServer) renderResources(ch *chart.Chart, values chartutil.Values, subNotes bool, vs chartutil.VersionSet) ([]*release.Hook, *bytes.Buffer, string, error) {
 	// Guard to make sure Tiller is at the right version to handle this chart.
 	sver := version.GetVersion()
+	// since our rancher version will always be va.b.c-rancherX, we only take the first part before dash into comparison
+	sver = strings.SplitN(sver, "-", 2)[0]
 	if ch.Metadata.TillerVersion != "" &&
 		!version.IsCompatibleRange(ch.Metadata.TillerVersion, sver) {
 		return nil, nil, "", fmt.Errorf("Chart incompatible with Tiller %s", sver)
@@ -394,7 +396,7 @@ func (s *ReleaseServer) execHook(hs []*release.Hook, name, namespace, hook strin
 		}
 
 		b := bytes.NewBufferString(h.Manifest)
-		if err := kubeCli.Create(namespace, b, timeout, false); err != nil {
+		if err := kubeCli.Create(name, namespace, b, timeout, false); err != nil {
 			s.Log("warning: Release %s %s %s failed: %s", name, hook, h.Path, err)
 			return err
 		}

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -499,8 +499,8 @@ type updateFailingKubeClient struct {
 	environment.PrintingKubeClient
 }
 
-func (u *updateFailingKubeClient) Update(namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
-	return u.UpdateWithOptions(namespace, originalReader, modifiedReader, kube.UpdateOptions{
+func (u *updateFailingKubeClient) Update(name, namespace string, originalReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+	return u.UpdateWithOptions(name, namespace, originalReader, modifiedReader, kube.UpdateOptions{
 		Force:      force,
 		Recreate:   recreate,
 		Timeout:    timeout,
@@ -508,7 +508,7 @@ func (u *updateFailingKubeClient) Update(namespace string, originalReader, modif
 	})
 }
 
-func (u *updateFailingKubeClient) UpdateWithOptions(namespace string, originalReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
+func (u *updateFailingKubeClient) UpdateWithOptions(name, namespace string, originalReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
 	return errors.New("Failed update in kube client")
 }
 
@@ -598,7 +598,7 @@ func (kc *mockHooksKubeClient) makeManifest(r io.Reader) (*mockHooksManifest, er
 
 	return manifest, nil
 }
-func (kc *mockHooksKubeClient) Create(ns string, r io.Reader, timeout int64, shouldWait bool) error {
+func (kc *mockHooksKubeClient) Create(name, ns string, r io.Reader, timeout int64, shouldWait bool) error {
 	manifest, err := kc.makeManifest(r)
 	if err != nil {
 		return err
@@ -645,10 +645,10 @@ func (kc *mockHooksKubeClient) WatchUntilReady(ns string, r io.Reader, timeout i
 
 	return nil
 }
-func (kc *mockHooksKubeClient) Update(ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
+func (kc *mockHooksKubeClient) Update(name, ns string, currentReader, modifiedReader io.Reader, force bool, recreate bool, timeout int64, shouldWait bool) error {
 	return nil
 }
-func (kc *mockHooksKubeClient) UpdateWithOptions(ns string, currentReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
+func (kc *mockHooksKubeClient) UpdateWithOptions(name, ns string, currentReader, modifiedReader io.Reader, opts kube.UpdateOptions) error {
 	return nil
 }
 func (kc *mockHooksKubeClient) Build(ns string, reader io.Reader) (kube.Result, error) {


### PR DESCRIPTION
This will rename the binaries created to `rancher-helm` and `rancher-tiller` along with adding rancher required things. 

Rancher will needs some updates to use this new version:
1. binary name changes
2. Probe flag updated to `probe-listen` for tiller. This is now builtin to tiller. 