### PR TITLE
[WIP] Support deploying into multiple namespaces

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -115,10 +115,6 @@ func (c *Client) Create(name, namespace string, reader io.Reader, timeout int64,
 		return buildErr
 	}
 	for _, info := range infos {
-		// if resource is created under a namespace we have to make sure the namespace matches
-		if info.Namespace != namespace && info.Namespace != "" {
-			return fmt.Errorf("resource's namespace %s doesn't match the current namespace %s", info.Namespace, namespace)
-		}
 		if name != "" {
 			raw := info.Object.(runtime.Unstructured).UnstructuredContent()
 			label, ok := GetValue(raw, "metadata", "labels")


### PR DESCRIPTION
**Problem:**
The rancher-helm could not deploy resources into different but has-permissions Namespaces.

**Solution:**
Remove the detection when creating Kubernetes resources. With [the `special user-permission kubeconfig` created](https://github.com/rancher/rancher/blob/22eed9388e1d1cc96a4184aaf33ad4f1153f1d6f/pkg/controllers/user/helm/controller.go#L358), the helm can't deploy resources into an unexpected Namespace. On the other hand, helm could install/uninstall resources to/from multiple Namespaces.
