### PR TITLE
[v3.11.1] Rancher changes for Helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PKG         := ./...
 TAGS        :=
 TESTS       := .
 TESTFLAGS   :=
-LDFLAGS     := -w -s
+LDFLAGS     := -w -s -extldflags "-static"
 GOFLAGS     :=
 CGO_ENABLED ?= 0
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -171,6 +171,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.SkipCRDs, "skip-crds", false, "if set, no CRDs will be installed. By default, CRDs are installed if not already present")
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&client.ForceAdopt, "force-adopt", false, "force adopt resources that were created outside helm")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -42,17 +42,4 @@ func checkPerms() {
 		}
 		kc = filepath.Join(u.HomeDir, ".kube", "config")
 	}
-	fi, err := os.Stat(kc)
-	if err != nil {
-		// DO NOT error if no KubeConfig is found. Not all commands require one.
-		return
-	}
-
-	perm := fi.Mode().Perm()
-	if perm&0040 > 0 {
-		warning("Kubernetes configuration file is group-readable. This is insecure. Location: %s", kc)
-	}
-	if perm&0004 > 0 {
-		warning("Kubernetes configuration file is world-readable. This is insecure. Location: %s", kc)
-	}
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -102,6 +102,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						fmt.Fprintf(out, "Release %q does not exist. Installing it now.\n", args[0])
 					}
 					instClient := action.NewInstall(cfg)
+					instClient.ForceAdopt = client.Adopt
 					instClient.CreateNamespace = createNamespace
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.Force = client.Force
@@ -234,6 +235,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&client.Adopt, "force-adopt", false, "force adopt resources that were created outside helm")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -370,7 +370,9 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 // Init initializes the action configuration
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string, log DebugLog) error {
 	kc := kube.New(getter)
-	kc.Log = log
+	kc.Log = func(s string, i ...interface{}) {
+		fmt.Printf(s+"\n", i...)
+	}
 
 	lazyClient := &lazyClient{
 		namespace: namespace,

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -480,7 +480,7 @@ func (i *Install) availableName() error {
 	releaseutil.Reverse(h, releaseutil.SortByRevision)
 	rel := h[0]
 
-	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed) {
+	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed || st == release.StatusPendingInstall) {
 		return nil
 	}
 	return errors.New("cannot re-use a name that is still in use")

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -70,6 +70,7 @@ type Install struct {
 
 	ClientOnly               bool
 	Force                    bool
+	ForceAdopt               bool
 	CreateNamespace          bool
 	DryRun                   bool
 	DisableHooks             bool
@@ -293,7 +294,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	// deleting the release because the manifest will be pointing at that
 	// resource
 	if !i.ClientOnly && !isUpgrade && len(resources) > 0 {
-		toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace)
+		toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace, i.ForceAdopt)
 		if err != nil {
 			return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with install")
 		}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -45,6 +45,7 @@ type Upgrade struct {
 
 	ChartPathOptions
 
+	Adopt bool
 	// Install is a purely informative flag that indicates whether this upgrade was done in "install" mode.
 	//
 	// Applications may use this to determine whether this Upgrade operation was done as part of a
@@ -298,7 +299,7 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		}
 	}
 
-	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace)
+	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace, u.Adopt)
 	if err != nil {
 		return nil, errors.Wrap(err, "rendered manifests contain a resource that already exists. Unable to continue with update")
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -51,7 +51,7 @@ const (
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )
 
-func existingResourceConflict(resources kube.ResourceList, releaseName, releaseNamespace string) (kube.ResourceList, error) {
+func existingResourceConflict(resources kube.ResourceList, releaseName, releaseNamespace string, forceAdopt bool) (kube.ResourceList, error) {
 	var requireUpdate kube.ResourceList
 
 	err := resources.Visit(func(info *resource.Info, err error) error {
@@ -68,9 +68,11 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
 		}
 
-		// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
-		if err := checkOwnership(existing, releaseName, releaseNamespace); err != nil {
-			return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
+		if !forceAdopt {
+			// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
+			if err := checkOwnership(existing, releaseName, releaseNamespace); err != nil {
+				return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
+			}
 		}
 
 		requireUpdate.Append(info)

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -23,12 +23,26 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 
 	"helm.sh/helm/v3/pkg/kube"
 )
 
-var accessor = meta.NewAccessor()
+var (
+	accessor = meta.NewAccessor()
+
+	provisioningClusterGVK = schema.GroupVersionKind{
+		Group:   "provisioning.cattle.io",
+		Version: "v1",
+		Kind:    "Cluster",
+	}
+
+	MachineConfigGV = schema.GroupVersion{
+		Group:   "rke-machine-config.cattle.io",
+		Version: "v1",
+	}
+)
 
 const (
 	appManagedByLabel              = "app.kubernetes.io/managed-by"
@@ -48,7 +62,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 		helper := resource.NewHelper(info.Client, info.Mapping)
 		existing, err := helper.Get(info.Namespace, info.Name)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || shouldIgnore(info, err) {
 				return nil
 			}
 			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
@@ -64,6 +78,20 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 	})
 
 	return requireUpdate, err
+}
+
+// If resource is cluster.provisioning.cattle.io or *.rke-machine-config.cattle.io, we should ignore permission error.
+// This is because standard user in rancher won't have the permission to check it until they have created it. Issue: https://github.com/rancher/rancher/issues/34277#issuecomment-901308458
+func shouldIgnore(info *resource.Info, err error) bool {
+	if info.Mapping != nil {
+		if info.Mapping.GroupVersionKind == provisioningClusterGVK || info.Mapping.GroupVersionKind.GroupVersion() == MachineConfigGV {
+			if apierrors.IsForbidden(err) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) error {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -281,7 +281,9 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true))
 	w := waiter{
 		c:       checker,
-		log:     c.Log,
+		log: func(s string, i ...interface{}) {
+			fmt.Printf(s+"\n", i...)
+		},
 		timeout: timeout,
 	}
 	return w.waitForResources(resources)
@@ -295,8 +297,10 @@ func (c *Client) WaitWithJobs(resources ResourceList, timeout time.Duration) err
 	}
 	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true), CheckJobs(true))
 	w := waiter{
-		c:       checker,
-		log:     c.Log,
+		c: checker,
+		log: func(s string, i ...interface{}) {
+			fmt.Printf(s+"\n", i...)
+		},
 		timeout: timeout,
 	}
 	return w.waitForResources(resources)


### PR DESCRIPTION
Cherry-picking Rancher commits and applying them to upstream tag `v3.11.1`. New tag will be `v3.11.1-rancher1`.