### PR TITLE
removed unused function

### DIFF
--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -17,29 +17,3 @@ limitations under the License.
 */
 
 package main
-
-import (
-	"bytes"
-	"io"
-	"os"
-)
-
-func checkPermsStderr() (string, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-
-	stderr := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = stderr
-	}()
-
-	checkPerms()
-	w.Close()
-
-	var text bytes.Buffer
-	io.Copy(&text, r)
-	return text.String(), nil
-}


### PR DESCRIPTION
to avoid linting error
```
GO111MODULE=on golangci-lint run
Error: cmd/helm/root_unix_test.go:27:6: func `checkPermsStderr` is unused (unused)
func checkPermsStderr() (string, error) {
     ^
make: *** [Makefile:11[7](https://github.com/rancher/helm/actions/runs/6033676741/job/16370736133#step:5:8): test-style] Error 1
Error: Process completed with exit code 2.
```