### PR TITLE
[v1.28] Helm v3.13.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PKG         := ./...
 TAGS        :=
 TESTS       := .
 TESTFLAGS   :=
-LDFLAGS     := -w -s
+LDFLAGS     := -w -s -extldflags "-static"
 GOFLAGS     :=
 CGO_ENABLED ?= 0
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -191,6 +191,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.SubNotes, "render-subchart-notes", false, "if set, render subchart notes along with the parent")
 	f.StringToStringVarP(&client.Labels, "labels", "l", nil, "Labels that would be added to release metadata. Should be divided by comma.")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&client.ForceAdopt, "force-adopt", false, "force adopt resources that were created outside helm")
 	addValueOptionsFlags(f, valueOpts)
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -42,17 +42,4 @@ func checkPerms() {
 		}
 		kc = filepath.Join(u.HomeDir, ".kube", "config")
 	}
-	fi, err := os.Stat(kc)
-	if err != nil {
-		// DO NOT error if no KubeConfig is found. Not all commands require one.
-		return
-	}
-
-	perm := fi.Mode().Perm()
-	if perm&0040 > 0 {
-		warning("Kubernetes configuration file is group-readable. This is insecure. Location: %s", kc)
-	}
-	if perm&0004 > 0 {
-		warning("Kubernetes configuration file is world-readable. This is insecure. Location: %s", kc)
-	}
 }

--- a/cmd/helm/root_unix.go
+++ b/cmd/helm/root_unix.go
@@ -40,6 +40,6 @@ func checkPerms() {
 			// can proceed happily without a KUBECONFIG, so this is not a fatal error.
 			return
 		}
-		kc = filepath.Join(u.HomeDir, ".kube", "config")
+		_ = filepath.Join(u.HomeDir, ".kube", "config")
 	}
 }

--- a/cmd/helm/root_unix_test.go
+++ b/cmd/helm/root_unix_test.go
@@ -17,29 +17,3 @@ limitations under the License.
 */
 
 package main
-
-import (
-	"bytes"
-	"io"
-	"os"
-)
-
-func checkPermsStderr() (string, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-
-	stderr := os.Stderr
-	os.Stderr = w
-	defer func() {
-		os.Stderr = stderr
-	}()
-
-	checkPerms()
-	w.Close()
-
-	var text bytes.Buffer
-	io.Copy(&text, r)
-	return text.String(), nil
-}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -122,6 +122,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 						fmt.Fprintf(out, "Release %q does not exist. Installing it now.\n", args[0])
 					}
 					instClient := action.NewInstall(cfg)
+					instClient.ForceAdopt = client.Adopt
 					instClient.CreateNamespace = createNamespace
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.Force = client.Force
@@ -262,6 +263,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&client.Description, "description", "", "add a custom description")
 	f.BoolVar(&client.DependencyUpdate, "dependency-update", false, "update dependencies if they are missing before installing the chart")
 	f.BoolVar(&client.EnableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&client.Adopt, "force-adopt", false, "force adopt resources that were created outside helm")
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	addValueOptionsFlags(f, valueOpts)
 	bindOutputFlag(cmd, &outfmt)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -368,7 +368,9 @@ func (cfg *Configuration) recordRelease(r *release.Release) {
 // Init initializes the action configuration
 func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namespace, helmDriver string, log DebugLog) error {
 	kc := kube.New(getter)
-	kc.Log = log
+	kc.Log = func(s string, i ...interface{}) {
+		fmt.Printf(s+"\n", i...)
+	}
 
 	lazyClient := &lazyClient{
 		namespace: namespace,

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -71,6 +71,7 @@ type Install struct {
 
 	ClientOnly               bool
 	Force                    bool
+	ForceAdopt               bool
 	CreateNamespace          bool
 	DryRun                   bool
 	DryRunOption             string
@@ -335,7 +336,7 @@ func (i *Install) RunWithContext(ctx context.Context, chrt *chart.Chart, vals ma
 	// deleting the release because the manifest will be pointing at that
 	// resource
 	if !i.ClientOnly && !isUpgrade && len(resources) > 0 {
-		toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace)
+		toBeAdopted, err = existingResourceConflict(resources, rel.Name, rel.Namespace, i.ForceAdopt)
 		if err != nil {
 			return nil, errors.Wrap(err, "Unable to continue with install")
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -526,7 +526,7 @@ func (i *Install) availableName() error {
 	releaseutil.Reverse(h, releaseutil.SortByRevision)
 	rel := h[0]
 
-	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed) {
+	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed || st == release.StatusPendingInstall) {
 		return nil
 	}
 	return errors.New("cannot re-use a name that is still in use")

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -46,6 +46,7 @@ type Upgrade struct {
 
 	ChartPathOptions
 
+	Adopt bool
 	// Install is a purely informative flag that indicates whether this upgrade was done in "install" mode.
 	//
 	// Applications may use this to determine whether this Upgrade operation was done as part of a
@@ -327,7 +328,7 @@ func (u *Upgrade) performUpgrade(ctx context.Context, originalRelease, upgradedR
 		}
 	}
 
-	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace)
+	toBeUpdated, err := existingResourceConflict(toBeCreated, upgradedRelease.Name, upgradedRelease.Namespace, u.Adopt)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to continue with update")
 	}

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -23,12 +23,26 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 
 	"helm.sh/helm/v3/pkg/kube"
 )
 
-var accessor = meta.NewAccessor()
+var (
+	accessor = meta.NewAccessor()
+
+	provisioningClusterGVK = schema.GroupVersionKind{
+		Group:   "provisioning.cattle.io",
+		Version: "v1",
+		Kind:    "Cluster",
+	}
+
+	MachineConfigGV = schema.GroupVersion{
+		Group:   "rke-machine-config.cattle.io",
+		Version: "v1",
+	}
+)
 
 const (
 	appManagedByLabel              = "app.kubernetes.io/managed-by"
@@ -48,7 +62,7 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 		helper := resource.NewHelper(info.Client, info.Mapping)
 		existing, err := helper.Get(info.Namespace, info.Name)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || shouldIgnore(info, err) {
 				return nil
 			}
 			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
@@ -66,6 +80,20 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 	})
 
 	return requireUpdate, err
+}
+
+// If resource is cluster.provisioning.cattle.io or *.rke-machine-config.cattle.io, we should ignore permission error.
+// This is because standard user in rancher won't have the permission to check it until they have created it. Issue: https://github.com/rancher/rancher/issues/34277#issuecomment-901308458
+func shouldIgnore(info *resource.Info, err error) bool {
+	if info.Mapping != nil {
+		if info.Mapping.GroupVersionKind == provisioningClusterGVK || info.Mapping.GroupVersionKind.GroupVersion() == MachineConfigGV {
+			if apierrors.IsForbidden(err) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func checkOwnership(obj runtime.Object, releaseName, releaseNamespace string) error {

--- a/pkg/action/validate.go
+++ b/pkg/action/validate.go
@@ -37,7 +37,7 @@ const (
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )
 
-func existingResourceConflict(resources kube.ResourceList, releaseName, releaseNamespace string) (kube.ResourceList, error) {
+func existingResourceConflict(resources kube.ResourceList, releaseName, releaseNamespace string, forceAdopt bool) (kube.ResourceList, error) {
 	var requireUpdate kube.ResourceList
 
 	err := resources.Visit(func(info *resource.Info, err error) error {
@@ -54,9 +54,11 @@ func existingResourceConflict(resources kube.ResourceList, releaseName, releaseN
 			return errors.Wrapf(err, "could not get information about the resource %s", resourceString(info))
 		}
 
-		// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
-		if err := checkOwnership(existing, releaseName, releaseNamespace); err != nil {
-			return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
+		if !forceAdopt {
+			// Allow adoption of the resource if it is managed by Helm and is annotated with correct release name and namespace.
+			if err := checkOwnership(existing, releaseName, releaseNamespace); err != nil {
+				return fmt.Errorf("%s exists and cannot be imported into the current release: %s", resourceString(info), err)
+			}
 		}
 
 		requireUpdate.Append(info)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -290,7 +290,9 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true))
 	w := waiter{
 		c:       checker,
-		log:     c.Log,
+		log: func(s string, i ...interface{}) {
+			fmt.Printf(s+"\n", i...)
+		},
 		timeout: timeout,
 	}
 	return w.waitForResources(resources)
@@ -304,8 +306,10 @@ func (c *Client) WaitWithJobs(resources ResourceList, timeout time.Duration) err
 	}
 	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true), CheckJobs(true))
 	w := waiter{
-		c:       checker,
-		log:     c.Log,
+		c: checker,
+		log: func(s string, i ...interface{}) {
+			fmt.Printf(s+"\n", i...)
+		},
 		timeout: timeout,
 	}
 	return w.waitForResources(resources)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -289,7 +289,7 @@ func (c *Client) Wait(resources ResourceList, timeout time.Duration) error {
 	}
 	checker := NewReadyChecker(cs, c.Log, PausedAsReady(true))
 	w := waiter{
-		c:       checker,
+		c: checker,
 		log: func(s string, i ...interface{}) {
 			fmt.Printf(s+"\n", i...)
 		},


### PR DESCRIPTION
### Update
* Add support for K8s v1.28, [support matrix](https://helm.sh/docs/topics/version_skew/#supported-version-skew).
* Add helm v3.13.3 from upstream and cherry pick rancher specific commits from [v3.12.3-rancher1](https://github.com/rancher/helm/tree/v3.12.3-rancher1)

### TODO:
  * [ ] Create a new branch for helm v3.13.3 and then change the base branch for this PR.

### Related
* https://github.com/rancher/rancher/issues/43109